### PR TITLE
Fixed typing to silence PyCharm checking

### DIFF
--- a/arbol/arbol.py
+++ b/arbol/arbol.py
@@ -5,6 +5,7 @@ import sys
 import time
 from contextlib import contextmanager
 from threading import local
+from typing import Any
 
 try:
     # for color support, install ansicolors
@@ -85,7 +86,7 @@ def _colorise(text: str, fg: str):
         return text
 
 
-def aprint(*args, sep=' ', end='\n', file=None, separate_lines=False):
+def aprint(*args: Any, sep=' ', end='\n', file=None, separate_lines=False):
     """
     Arbol version of print. Text will be printed following the arborescent structure of sections.
 


### PR DESCRIPTION
PyCharm was considering `*args` as a list-only input.