### PR TITLE
Fix bugs from code review, add CI and __all__

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,7 +7,30 @@ on:
   workflow_dispatch:
 
 jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.9", "3.13"]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        run: pip install pytest
+
+      - name: Install package
+        run: pip install -e .
+
+      - name: Run tests
+        run: pytest arbol/tests/ -v
+
   build:
+    needs: test
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,49 @@
+name: Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        run: pip install pytest
+
+      - name: Install package
+        run: pip install -e .
+
+      - name: Run tests
+        run: pytest arbol/tests/ -v
+
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+
+      - name: Install ruff
+        run: pip install ruff
+
+      - name: Lint
+        run: ruff check arbol/
+
+      - name: Check formatting
+        run: ruff format --check arbol/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,7 +31,7 @@ hatch shell        # Enter environment shell
 
 ## Architecture
 
-The entire library is in `arbol/arbol.py` (~285 lines). Key components:
+The entire library is in `arbol/arbol.py` (~390 lines). Key components:
 
 - **`Arbol` class**: Configuration holder using class variables. Manages global state including `_depth` (current nesting level), output flags, colors, and Unicode box-drawing characters. Uses thread-local storage for capture state.
 

--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,7 @@ TODAY := $(shell date +%Y.%-m.%-d)
 # Bump version to today's date and publish
 publish: check test
 	@echo "Current version: $(CURRENT_VERSION)"
-	@if echo "$(CURRENT_VERSION)" | grep -q "^$(TODAY)"; then \
+	@if echo "$(CURRENT_VERSION)" | grep -q "^$(TODAY)$$"; then \
 		echo "Error: Version $(CURRENT_VERSION) is already today's date."; \
 		echo "Use 'make publish-patch' for same-day releases."; \
 		exit 1; \

--- a/arbol/__init__.py
+++ b/arbol/__init__.py
@@ -1,5 +1,7 @@
 __version__ = '2026.2.1'
 
+__all__ = ['Arbol', 'aprint', 'asection', 'section', 'acapture']
+
 from arbol.arbol import Arbol as Arbol
 from arbol.arbol import acapture as acapture
 from arbol.arbol import aprint as aprint

--- a/arbol/tests/test_arbol.py
+++ b/arbol/tests/test_arbol.py
@@ -107,15 +107,15 @@ class TestAprint:
         """Test aprint with empty string."""
         aprint('')
         captured = capsys.readouterr()
-        # Empty string still produces tree scaffold
+        # Empty string produces no output (empty lines are filtered out)
         assert captured.out == ''
 
     def test_no_arguments(self, capsys):
         """Test aprint with no arguments (like print())."""
         aprint()
         captured = capsys.readouterr()
-        # No args should work like print() - just outputs end character
-        assert captured.out == ''  # Empty because no content to show
+        # No args produces no output (empty lines are filtered out)
+        assert captured.out == ''
 
     def test_flush_parameter(self, capsys):
         """Test aprint with flush parameter (same as built-in print)."""


### PR DESCRIPTION
## Summary

- **Fix `end` parameter double-application in `aprint`** — e.g. `aprint('hi', end='!!')` produced `hi!!!!` instead of `hi!!`. Was masked for the default `end='\n'` because `split('\n')` consumed the trailing newline.
- **Fix `KeyboardInterrupt`/`SystemExit` leaking `_depth`** — changed `except Exception` to `except BaseException` in `asection` so Ctrl-C no longer permanently corrupts the depth counter.
- **Fix silent drop of elapsed time >= 24 hours** — added `else` clause to `_print_elapsed` formatting as days.
- **Fix `section` decorator losing function metadata** — added `@functools.wraps`.
- **Fix `flush` parameter silently ignored** in tree mode — plumbed through `native_print`.
- **Fix `set_log_max_depth` docstring** — said "clamped to minimum of 1" but actually clamps to 0.
- **Fix Makefile `publish` grep prefix-matching** — `2026.2.2` no longer falsely matches `2026.2.22`.
- **Add `__all__`** to `__init__.py` for explicit public API.
- **Add CI test workflow** (`test.yml`) — pytest across Python 3.9–3.13 + ruff lint/format check on push/PR.
- **Add test gate to `publish.yml`** — build now requires tests to pass before publishing.

## Test plan

- [x] All 42 existing tests pass
- [x] Ruff lint: all checks passed
- [x] Ruff format: 6 files already formatted
- [x] Demo runs correctly end-to-end
- [x] Edge case battery: KeyboardInterrupt, SystemExit, custom `end`/`sep`/`flush`, `__all__`, Makefile grep compatibility
- [ ] CI workflows run on this PR (test.yml)

🤖 Generated with [Claude Code](https://claude.com/claude-code)